### PR TITLE
Add persistent brand-styled navigation bar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ function App() {
     <Router>
       <NavBar />
       {/* push content down so it's not hidden under fixed nav */}
-      <div className="max-w-4xl mx-auto p-6 pt-24">
+      <div className="content-container">
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/enquiries" element={<EnquiriesPage />} />

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,35 +1,35 @@
-import { Link, useLocation } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 export default function NavBar() {
-  const location = useLocation();
-
-  const linkClasses = (path) =>
-    `px-4 py-2 rounded-md font-medium transition-colors ${
-      location.pathname === path
-        ? "bg-[var(--rainbows-red)] text-white"
-        : "text-[var(--rainbows-dark-blue)] hover:bg-[var(--rainbows-light-blue)]"
-    }`;
+  const linkClass = ({ isActive }) =>
+    `navbar-link${isActive ? " active" : ""}`;
 
   return (
-    <nav className="fixed top-0 left-0 w-full bg-white shadow-md z-50">
-      <div className="max-w-4xl mx-auto flex items-center justify-between px-6 py-3">
-        <div className="flex items-center space-x-2">
-          <span className="text-2xl">🌈</span>
-          <span className="text-xl font-bold text-[var(--rainbows-red)]">
-            Rainbow Planner
+    <nav className="navbar">
+      <div className="navbar-content">
+        <div className="navbar-brand">
+          <span role="img" aria-label="rainbow">
+            🌈
           </span>
+          <span className="brand-name">Rainbow Planner</span>
         </div>
-        <div className="flex space-x-4">
-          <Link to="/" className={linkClasses("/")}>
-            Home
-          </Link>
-          <Link to="/enquiries" className={linkClasses("/enquiries")}>
-            Enquiries
-          </Link>
-          <Link to="/members" className={linkClasses("/members")}>
-            Members
-          </Link>
-        </div>
+        <ul className="navbar-links">
+          <li>
+            <NavLink to="/" end className={linkClass}>
+              Home
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/enquiries" className={linkClass}>
+              Enquiries
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/members" className={linkClass}>
+              Members
+            </NavLink>
+          </li>
+        </ul>
       </div>
     </nav>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,3 +98,67 @@ tbody tr:nth-child(even) {
   width: 90%;
   max-width: 400px;
 }
+
+/* 7. Navigation bar */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: var(--rainbows-light-blue);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.navbar-content {
+  max-width: 1024px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+}
+
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.brand-name {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--rainbows-red);
+}
+
+.navbar-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.navbar-link {
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  color: var(--rainbows-dark-blue);
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.navbar-link:hover {
+  background: var(--rainbows-yellow);
+}
+
+.navbar-link.active {
+  background: var(--rainbows-red);
+  color: var(--surface-white);
+}
+
+/* 8. Content container */
+.content-container {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  margin-top: 6rem; /* ensure content not hidden under fixed navbar */
+}


### PR DESCRIPTION
## Summary
- Convert NavBar to use semantic markup with NavLink and brand styling
- Add fixed navigation bar and content container using branded colours

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b0bffab624832eb128c561f01a32c5