### PR TITLE
Improve navigation and table management

### DIFF
--- a/frontend/src/components/EnquiriesList.jsx
+++ b/frontend/src/components/EnquiriesList.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
-import AddEnquiryForm from "./AddEnquiryForm";
+import AddEnquiryModal from "./AddEnquiryModal";
 
 export default function EnquiriesList() {
   const [enquiries, setEnquiries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [showModal, setShowModal] = useState(false);
 
   const loadEnquiries = () => {
     fetch("/api/enquiries")
@@ -44,41 +45,89 @@ export default function EnquiriesList() {
 
   return (
     <div>
-      <AddEnquiryForm
-        onAdded={(newEnquiry) =>
-          setEnquiries((prev) => [newEnquiry, ...prev])
-        }
-      />
+      <button
+        onClick={() => setShowModal(true)}
+        className="mb-4 bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+      >
+        Add Enquiry
+      </button>
+
+      {showModal && (
+        <AddEnquiryModal
+          onClose={() => setShowModal(false)}
+          onAdded={() => {
+            setShowModal(false);
+            loadEnquiries();
+          }}
+        />
+      )}
 
       <h2 className="text-xl font-bold mb-4">Enquiries</h2>
       {enquiries.length === 0 ? (
         <p>No enquiries yet.</p>
       ) : (
-        <ul className="space-y-2">
-          {enquiries.map((e) => (
-            <li
-              key={e.id}
-              className="border p-3 rounded flex justify-between items-center"
-            >
-              <div>
-                <p className="font-semibold">{e.name}</p>
-                <p className="text-sm text-gray-600">
-                  Status: {e.status_label || "Unknown"} | DOB:{" "}
-                  {new Date(e.dob).toLocaleDateString()}
-                </p>
-              </div>
-              {e.status_label !== "Promoted" && (
-                <button
-                  onClick={() => promote(e.id)}
-                  className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-                >
-                  Promote
-                </button>
-              )}
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="p-2 border">ID</th>
+                <th className="p-2 border">Name</th>
+                <th className="p-2 border">DOB</th>
+                <th className="p-2 border">Enquiry Date</th>
+                <th className="p-2 border">Status ID</th>
+                <th className="p-2 border">Status</th>
+                <th className="p-2 border">Created</th>
+                <th className="p-2 border">Updated</th>
+                <th className="p-2 border">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {enquiries.map((e) => (
+                <tr key={e.id} className="text-center">
+                  <td className="p-2 border">{e.id}</td>
+                  <td className="p-2 border">{e.name}</td>
+                  <td className="p-2 border">
+                    {new Date(e.dob).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {new Date(e.enquiry_date).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">{e.status_id}</td>
+                  <td className="p-2 border">{e.status_label || "Unknown"}</td>
+                  <td className="p-2 border">
+                    {new Date(e.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {new Date(e.updated_at).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {e.status_label !== "Promoted" && (
+                      <select
+                        defaultValue=""
+                        onChange={(ev) => {
+                          if (ev.target.value === "promote") {
+                            ev.target.value = "";
+                            if (window.confirm("Promote this enquiry?")) {
+                              promote(e.id);
+                            }
+                          }
+                        }}
+                        className="border rounded px-2 py-1"
+                      >
+                        <option value="" disabled>
+                          Actions
+                        </option>
+                        <option value="promote">Promote</option>
+                      </select>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
 }
+

--- a/frontend/src/components/MembersList.jsx
+++ b/frontend/src/components/MembersList.jsx
@@ -6,7 +6,6 @@ export default function MembersList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Load members + exit reasons on mount
   useEffect(() => {
     Promise.all([
       fetch("/api/members").then((res) => {
@@ -38,7 +37,6 @@ export default function MembersList() {
       });
       if (!res.ok) throw new Error("Exit failed");
 
-      // Update list locally
       setMembers((prev) =>
         prev.map((m) =>
           m.id === id
@@ -60,48 +58,79 @@ export default function MembersList() {
       {members.length === 0 ? (
         <p>No members yet.</p>
       ) : (
-        <ul className="space-y-2">
-          {members.map((m) => (
-            <li
-              key={m.id}
-              className="border p-3 rounded flex justify-between items-center"
-            >
-              <div>
-                <p className="font-semibold">{m.name}</p>
-                <p className="text-sm text-gray-600">
-                  DOB: {new Date(m.dob).toLocaleDateString()} <br />
-                  Joined: {new Date(m.join_date).toLocaleDateString()} <br />
-                  {m.exit_date ? (
-                    <>
-                      Exited: {new Date(m.exit_date).toLocaleDateString()} <br />
-                      Reason: {m.exit_reason_label || "Unknown"}
-                    </>
-                  ) : (
-                    <span className="text-green-600">Active</span>
-                  )}
-                </p>
-              </div>
-
-              {!m.exit_date && (
-                <select
-                  onChange={(e) => exitMember(m.id, e.target.value)}
-                  defaultValue=""
-                  className="ml-4 border rounded px-2 py-1"
-                >
-                  <option value="" disabled>
-                    Exit...
-                  </option>
-                  {exitReasons.map((r) => (
-                    <option key={r.id} value={r.id}>
-                      {r.label}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="p-2 border">ID</th>
+                <th className="p-2 border">Enquiry ID</th>
+                <th className="p-2 border">Name</th>
+                <th className="p-2 border">DOB</th>
+                <th className="p-2 border">Join Date</th>
+                <th className="p-2 border">Exit Date</th>
+                <th className="p-2 border">Exit Reason ID</th>
+                <th className="p-2 border">Exit Reason</th>
+                <th className="p-2 border">Created</th>
+                <th className="p-2 border">Updated</th>
+                <th className="p-2 border">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.id} className="text-center">
+                  <td className="p-2 border">{m.id}</td>
+                  <td className="p-2 border">{m.enquiry_id ?? "-"}</td>
+                  <td className="p-2 border">{m.name}</td>
+                  <td className="p-2 border">
+                    {new Date(m.dob).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {new Date(m.join_date).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {m.exit_date
+                      ? new Date(m.exit_date).toLocaleDateString()
+                      : "-"}
+                  </td>
+                  <td className="p-2 border">{m.exit_reason_id || "-"}</td>
+                  <td className="p-2 border">{m.exit_reason_label || "-"}</td>
+                  <td className="p-2 border">
+                    {new Date(m.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {new Date(m.updated_at).toLocaleDateString()}
+                  </td>
+                  <td className="p-2 border">
+                    {!m.exit_date && (
+                      <select
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (val) {
+                            e.target.value = "";
+                            exitMember(m.id, val);
+                          }
+                        }}
+                        defaultValue=""
+                        className="border rounded px-2 py-1"
+                      >
+                        <option value="" disabled>
+                          Exit...
+                        </option>
+                        {exitReasons.map((r) => (
+                          <option key={r.id} value={r.id}>
+                            {r.label}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
 }
+

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -7,18 +7,13 @@ export default function NavBar() {
   return (
     <nav className="navbar">
       <div className="navbar-content">
-        <div className="navbar-brand">
+        <NavLink to="/" className="navbar-brand">
           <span role="img" aria-label="rainbow">
             🌈
           </span>
           <span className="brand-name">Rainbow Planner</span>
-        </div>
+        </NavLink>
         <ul className="navbar-links">
-          <li>
-            <NavLink to="/" end className={linkClass}>
-              Home
-            </NavLink>
-          </li>
           <li>
             <NavLink to="/enquiries" className={linkClass}>
               Enquiries

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,16 +2,16 @@ import { Link } from "react-router-dom";
 
 export default function Home() {
   return (
-    <div className="space-x-4">
+    <div className="flex justify-center gap-4 mt-8">
       <Link
         to="/enquiries"
-        className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        className="px-6 py-3 bg-blue-500 text-white font-semibold rounded shadow hover:bg-blue-600"
       >
         Enquiries
       </Link>
       <Link
         to="/members"
-        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+        className="px-6 py-3 bg-green-600 text-white font-semibold rounded shadow hover:bg-green-700"
       >
         Members
       </Link>


### PR DESCRIPTION
## Summary
- Link the "Rainbow Planner" brand back to the homepage and remove the dedicated Home link
- Add styling to the Enquiries and Members buttons on the landing page
- Replace inline enquiry form with modal and list all enquiry fields with an actions dropdown and promotion confirmation
- Show every field for members in a tabular view, including exit details

## Testing
- `npm run lint --prefix frontend`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c34a0c28832e9ff720682acdbcfd