### PR TITLE
Show enquiry date and user detail popouts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource/poppins": "^5.2.6",
+        "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"
@@ -2142,7 +2143,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2252,6 +2252,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2314,6 +2326,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2457,6 +2478,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2487,6 +2519,12 @@
       "peerDependencies": {
         "react": "^19.1.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@fontsource/poppins": "^5.2.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/components/DetailsModal.jsx
+++ b/frontend/src/components/DetailsModal.jsx
@@ -1,0 +1,30 @@
+import PropTypes from "prop-types";
+
+export default function DetailsModal({ title, details, onClose }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-6 rounded shadow-lg w-96">
+        <h3 className="text-lg font-bold mb-4">{title}</h3>
+        <div className="space-y-1">
+          {Object.entries(details).map(([label, value]) => (
+            <div key={label} className="flex justify-between">
+              <span className="font-medium">{label}</span>
+              <span>{value}</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onClose} className="px-3 py-1 rounded border">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DetailsModal.propTypes = {
+  title: PropTypes.string.isRequired,
+  details: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/frontend/src/pages/EnquiriesPage.jsx
+++ b/frontend/src/pages/EnquiriesPage.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import AddEnquiryModal from "../components/AddEnquiryModal";
+import DetailsModal from "../components/DetailsModal";
 
 export default function EnquiriesPage() {
   const [enquiries, setEnquiries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
+  const [selectedEnquiry, setSelectedEnquiry] = useState(null);
 
   const loadEnquiries = () => {
     fetch("/api/enquiries")
@@ -43,6 +45,7 @@ export default function EnquiriesPage() {
           <tr className="bg-gray-100">
             <th className="p-2 border">Name</th>
             <th className="p-2 border">DOB</th>
+            <th className="p-2 border">Enquiry Date</th>
             <th className="p-2 border">Status</th>
             <th className="p-2 border">Action</th>
           </tr>
@@ -50,8 +53,18 @@ export default function EnquiriesPage() {
         <tbody>
           {enquiries.map((e) => (
             <tr key={e.id}>
-              <td className="p-2 border">{e.name}</td>
-              <td className="p-2 border">{new Date(e.dob).toLocaleDateString()}</td>
+              <td
+                className="p-2 border text-blue-600 cursor-pointer"
+                onClick={() => setSelectedEnquiry(e)}
+              >
+                {e.name}
+              </td>
+              <td className="p-2 border">
+                {new Date(e.dob).toLocaleDateString()}
+              </td>
+              <td className="p-2 border">
+                {new Date(e.enquiry_date).toLocaleDateString()}
+              </td>
               <td className="p-2 border">{e.status_label}</td>
               <td className="p-2 border">
                 {e.status_label !== "Promoted" && (
@@ -75,6 +88,22 @@ export default function EnquiriesPage() {
             setShowModal(false);
             loadEnquiries();
           }}
+        />
+      )}
+
+      {selectedEnquiry && (
+        <DetailsModal
+          title="Enquiry Details"
+          details={{
+            ID: selectedEnquiry.id,
+            Name: selectedEnquiry.name,
+            "Date of Birth": new Date(selectedEnquiry.dob).toLocaleDateString(),
+            "Enquiry Date": new Date(selectedEnquiry.enquiry_date).toLocaleDateString(),
+            Status: selectedEnquiry.status_label,
+            "Created At": new Date(selectedEnquiry.created_at).toLocaleString(),
+            "Updated At": new Date(selectedEnquiry.updated_at).toLocaleString(),
+          }}
+          onClose={() => setSelectedEnquiry(null)}
         />
       )}
     </div>

--- a/frontend/src/pages/MembersPage.jsx
+++ b/frontend/src/pages/MembersPage.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
+import DetailsModal from "../components/DetailsModal";
 
 export default function MembersPage() {
   const [members, setMembers] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [selectedMember, setSelectedMember] = useState(null);
 
   const loadMembers = () => {
     fetch("/api/members")
@@ -34,9 +36,16 @@ export default function MembersPage() {
         <tbody>
           {members.map((m) => (
             <tr key={m.id}>
-              <td className="p-2 border">{m.name}</td>
+              <td
+                className="p-2 border text-blue-600 cursor-pointer"
+                onClick={() => setSelectedMember(m)}
+              >
+                {m.name}
+              </td>
               <td className="p-2 border">{new Date(m.dob).toLocaleDateString()}</td>
-              <td className="p-2 border">{new Date(m.join_date).toLocaleDateString()}</td>
+              <td className="p-2 border">
+                {new Date(m.join_date).toLocaleDateString()}
+              </td>
               <td className="p-2 border">
                 {m.exit_date
                   ? `Exited (${m.exit_reason_label || "Unknown"})`
@@ -46,6 +55,26 @@ export default function MembersPage() {
           ))}
         </tbody>
       </table>
+
+      {selectedMember && (
+        <DetailsModal
+          title="Member Details"
+          details={{
+            ID: selectedMember.id,
+            "Enquiry ID": selectedMember.enquiry_id,
+            Name: selectedMember.name,
+            "Date of Birth": new Date(selectedMember.dob).toLocaleDateString(),
+            "Join Date": new Date(selectedMember.join_date).toLocaleDateString(),
+            "Exit Date": selectedMember.exit_date
+              ? new Date(selectedMember.exit_date).toLocaleDateString()
+              : "N/A",
+            "Exit Reason": selectedMember.exit_reason_label || "N/A",
+            "Created At": new Date(selectedMember.created_at).toLocaleString(),
+            "Updated At": new Date(selectedMember.updated_at).toLocaleString(),
+          }}
+          onClose={() => setSelectedMember(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display enquiry_date on enquiries table
- add reusable DetailsModal component
- allow clicking names on enquiries and members pages to view full info in a pop-out

## Testing
- `npm run lint --prefix frontend`
- `npm test --prefix frontend` (fails: Missing script "test")
- `npm test --prefix backend` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b0c6009920832ea8c8901e18ebfce8